### PR TITLE
Reconfigure input dir for train.h5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # Build from kaggle python image
 FROM kaggle/python
 
-# Make kaggler user, wd, data for joblib
+# Make kaggler user, wd, data for joblib, input folder
 RUN useradd -m -s /bin/bash -N -u 1000 kaggler && \
-  mkdir -p /wd && mkdir -p /data && \
-  chown kaggler /wd && chown kaggler /data
+  mkdir -p /wd && chown kaggler /wd && \
+  mkdir -p /data && chown kaggler /data && \
+  mkdir -p /input && chown kaggler /input
 
 USER kaggler
 
@@ -16,7 +17,7 @@ ADD ./gym/kagglegym.py /home/kaggler/gym/kagglegym.py
 ADD /gym/__init__.py /home/kaggler/gym/__init__.py
 
 # Include the training data in input
-ADD  ./gym/input/train.h5 /home/kaggler/gym/input/train.h5
+ADD  ./gym/input/train.h5 /input/train.h5
 
 # Add the location of kagglegym to the pythonpath
 ENV PYTHONPATH="${PYTHONPATH}:/home/kaggler/gym"

--- a/gym/kagglegym.py
+++ b/gym/kagglegym.py
@@ -3,10 +3,6 @@ import pandas as pd
 import numpy as np
 from sklearn.metrics import r2_score
 
-# get the location of the HDFStore
-this_dir, this_filename = os.path.split(__file__)
-DATA_PATH = os.path.join(this_dir, "input", "train.h5")
-
 # This is taken from Frans Slothoubers post on the contest discussion forum.
 # https://www.kaggle.com/slothouber/two-sigma-financial-modeling/kagglegym-emulation
 
@@ -30,7 +26,7 @@ class Observation(object):
 
 class Environment(object):
     def __init__(self):
-        with pd.HDFStore(DATA_PATH, "r") as hfdata:
+        with pd.HDFStore("/input/train.h5", "r") as hfdata:
             self.timestamp = 0
             fullset = hfdata.get("train")
             self.unique_timestamp = fullset["timestamp"].unique()


### PR DESCRIPTION
This allows for importing the whole `train.h5` file in the same way as kaggle kernels:
```python
train = pd.read_hdf('../input/train.h5')
```